### PR TITLE
fix: handle SSR

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 import { useEffect, useState, useRef } from 'react';
 
 export function useLangDirection() {
+  // Check if we're in the server environment
+  if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    return 'ltr';   
+  }
   // Default target
   const element = document.getElementsByTagName('html')[0];
   // Read and set initial direction from default


### PR DESCRIPTION
Check if we're in the server environment. If yes and if there is no `document` object than return with the default `ltr` value.

fixes: https://github.com/davidicus/use-lang-direction/issues/20